### PR TITLE
LOGNAME FOR THE WIN!

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,4 +1,4 @@
-export DEFAULT_USER=`id -un`
+export DEFAULT_USER=`logname`
 
 source "$HOME/.antigen/antigen.zsh"
 


### PR DESCRIPTION
* `whoami` is not POSIX but it's generally my choice, since it's widely used/available
* `logname` is the POSIX equivalent to `whoami`, but it's not widely available, but since it works on MacOS, I would go for it :P